### PR TITLE
Mention need to install moreutils

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 # Installation instructions
 
+    $ brew install moreutils
     $ brew install nvie/tap/git-toolbelt
 
 # git-tools


### PR DESCRIPTION
Some git tools in the tool belt use `ifne` command which comes as part of moreutils. So mention need to install moreutils here.