### PR TITLE
Add a separate command to cleanup squash-merged branches locally

### DIFF
--- a/git-cleanup-squashed
+++ b/git-cleanup-squashed
@@ -1,0 +1,78 @@
+#!/bin/sh
+set -e
+
+usage () {
+    echo "usage: git cleanup-squashed [-nl]" >&2
+    echo >&2
+    echo "Deletes all branches that have already been squash-merged into master." >&2
+    echo >&2
+    echo "Options:" >&2
+    echo "-n    Dry-run" >&2
+    echo "-l    Local branches only, don't touch the remotes" >&2
+    echo "-h    Show this help" >&2
+}
+
+dryrun=0
+remotes=1
+while getopts nlh flag; do
+      case "$flag" in
+          n) dryrun=1;;
+          l) remotes=0;;
+          h) usage; exit 2;;
+      esac
+done
+shift $(($OPTIND - 1))
+
+#
+# This will clean up any local branch that has been merged into any of
+# the known "trunks". Trunks are any of:
+#
+#   - master (local) + origin/master
+#
+
+safegit() {
+    if [ "$dryrun" -eq 1 ]; then
+        echo git "$@"
+    else
+        git "$@"
+    fi
+}
+
+#
+# The Algorithm[tm]
+# - Create a temporary dangling squashed commit with git commit-tree
+# - Then use git cherry to check if the squashed commit has already been applied to master
+# - If it has, then delete the branch
+#
+
+git for-each-ref refs/heads/ "--format=%(refname:short)" | while read branch; do
+    # Skip if master branch
+    if [ $branch == "master" ]; then
+        continue
+    fi
+
+    # Find the merge base for this branch
+    merge_base=$(git merge-base master $branch)
+
+    # Get the tree object of the branch
+    branch_tree="$(git rev-parse $branch^{tree})"
+
+    # Create a squashed commit object of the branch tree with parent
+    # of $merge_base with a commit message of "_"
+    dangling_squashed_commit="$(git commit-tree $branch_tree -p $merge_base -m _)"
+
+    # Show a summary of what has yet to be applied
+    cherry_commit="$(git cherry master $dangling_squashed_commit)"
+
+    if [ "$cherry_commit" == "- $dangling_squashed_commit" ]; then
+        # If "- <commit-sha>", (ex. - "- 851cb44727") this means the
+        # commit is in master and can be dropped if you rebased
+        # against master
+        safegit branch -D $branch
+    else
+        # If "+ <commit-sha>", (ex. - "+ 851cb44727") this means the
+        # commit still needs to be kept so that it will be applied to
+        # master
+        echo "Branch $branch is not fully merged, Skipping..."
+    fi
+done


### PR DESCRIPTION
#### What's this PR do?
This adds in a separate `cleanup` command for squash-merged branches only.

When branches are squash-merged into a remote, the `cleanup` command does not work with this scenario as the nature of squashing is destructive.  It takes a series of commit objects and squashes them into a single _new_ commit.   This makes it hard to know which branches are in the remote after they have been squash-merged.

The cleanup strategy is taken from [not-an-aardvark/git-delete-squashed](https://github.com/not-an-aardvark/git-delete-squashed) but implements it more explicitly and should work across all versions of bash (avoids using `[[ ]]` for extra conditional power as a sacrifice, but generally not needed).

Ideally, this should be ported over to the main `git cleanup` script under a new flag, but I haven't found a compelling reason to add that overhead to the main `cleanup` script until this gets some usage.  Also, I didn't want to accidentally delete some remotes if I had a bug 😉 

#### How should this be manually tested?
You can try and run this under a dry-run flag with `git cleanup-squashed -n` to see what it would cleanup.