### PR TITLE
Remove production canary trunks

### DIFF
--- a/git-cleanup
+++ b/git-cleanup
@@ -4,7 +4,7 @@ set -e
 usage () {
     echo "usage: git cleanup [-nh]" >&2
     echo >&2
-    echo "Deletes all branches that have already been merged into master, production, or canary." >&2
+    echo "Deletes all branches that have already been merged into master." >&2
     echo "Removes those branches both locally and in the origin remote.  Will be " >&2
     echo "most conservative with deletions." >&2
     echo >&2
@@ -30,8 +30,6 @@ shift $(($OPTIND - 1))
 # merged into any of the known "trunks".  Trunks are any of:
 #
 #   - master (local) + origin/master
-#   - production (local) + origin/production
-#   - canary (local) + origin/canary
 #
 
 safegit () {
@@ -79,16 +77,12 @@ find_branch_base () {
 
 find_bases () {
     find_branch_base master
-    find_branch_base production
-    find_branch_base canary
 }
 
 bases=$(find_bases)
 
 for branch in $(git local-branches          \
-                | grep -vxF 'master'        \
-                | grep -vxF 'production'    \
-                | grep -vxF 'canary'); do
+                | grep -vxF 'master'); do
     for base in $bases; do
         if git contains "$base" "$branch"; then
             if ! git contains "$branch" "$base"; then
@@ -112,7 +106,7 @@ for remote in origin; do
 
     if [ $remotes -eq 1 ]; then
         branches_to_remove=""
-        for branch in $(git remote-branches "$remote" | grep -vEe '/(master|production|canary)$'); do
+        for branch in $(git remote-branches "$remote" | grep -vEe '/(master)$'); do
             for base in $bases; do
                 if git contains "$base" "$branch"; then
                     if ! git contains "$branch" "$base"; then


### PR DESCRIPTION
#### What's this PR do?
Removes old and specific references, `canary` and `production`, to trunks that `git cleanup` would be comparing against.

#### How should this be manually tested?
```
$ git cleanup
```