### PR TITLE
Remove reference to `moreutils` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Installation instructions
 
-    $ brew install moreutils fzf
+    $ brew install fzf
     $ brew tap nvie/tap
     $ brew install nvie/tap/git-toolbelt
 


### PR DESCRIPTION
Since `moreutils` is no longer used, we can remove it from the required installs.