### PR TITLE
Implement '-s' (since) option in 'git-active-branches'

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,8 +202,9 @@ commands for this, returns them machine-processable.  In the case of remote
 branches, can be asked to return only the branches in a specific remote.
 
 For `git active-branches`, a branch is deemed "active" if its head points to
-a commit authored in the last 3 weeks. This may also be specified with
-`git active-branches --since <date>` or `--after <date>`, using any date format
+a commit authored in the last 3 weeks, by default. An arbitrary date can be
+specified using either `git active-branches -s <date>` or `-a <date>`
+(mnemonic: "since" or "after"), using any date format
 [supported by `git log`][gitlog].
 
 
@@ -554,4 +555,4 @@ As you can see, `git-is-clean` is aware of any lurking "skipped" files, and
 won't report a clean working tree, as these assumed unchanged files often block
 the ability to check out different branches.
 
-[gitlog]: https://git-scm.com/book/en/v2/Git-Basics-Viewing-the-Commit-History
+[gitlog]: https://git-scm.com/book/en/v2/Git-Basics-Viewing-the-Commit-History#_limiting_log_output

--- a/README.md
+++ b/README.md
@@ -201,8 +201,10 @@ Returns a list of local or remote branches, but contrary to Git's default
 commands for this, returns them machine-processable.  In the case of remote
 branches, can be asked to return only the branches in a specific remote.
 
-A branch is deemed "active" if its head points to a commit authored in the last
-3 weeks.
+For `git active-branches`, a branch is deemed "active" if its head points to
+a commit authored in the last 3 weeks. This may also be specified with
+`git active-branches --since <date>` or `--after <date>`, using any date format
+[supported by `git log`][gitlog].
 
 
 ### git local-branch-exists / git remote-branch-exists / git tag-exists
@@ -551,3 +553,5 @@ Basic usage:
 As you can see, `git-is-clean` is aware of any lurking "skipped" files, and
 won't report a clean working tree, as these assumed unchanged files often block
 the ability to check out different branches.
+
+[gitlog]: https://git-scm.com/book/en/v2/Git-Basics-Viewing-the-Commit-History

--- a/git-active-branches
+++ b/git-active-branches
@@ -16,7 +16,7 @@ usage() {
     echo "https://git-scm.com/book/en/v2/Git-Basics-Viewing-the-Commit-History" >&2
 }
 
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
     if ! getopts a:s:h flag; then usage; exit 2; fi
     case "$flag" in
         a|s) since=$OPTARG; shift ;;

--- a/git-active-branches
+++ b/git-active-branches
@@ -1,9 +1,40 @@
 #!/bin/sh
 set -eu
 
-# TODO: Make the max age configurable
+since='3.weeks.ago'
+
+usage() {
+    echo "usage: git active-branches [--since|--after <date>]" >&2
+    echo >&2
+    echo "Unless specified, <date> defaults to \"$since\". For examples see:" >&2
+    echo "https://git-scm.com/book/en/v2/Git-Basics-Viewing-the-Commit-History" >&2
+    exit 2
+}
+
+if [ $# -gt 0 ]; then
+    case $1 in
+        # 'git log' accepts either '--since' or '--after' as synonyms
+        --since|--after)
+            [ $# -eq 2 ] || usage
+            since=$2
+            ;;
+        --since=*)
+            since=$(echo "$1" | sed 's/--since=\(.*\)/\1/')
+            ;;
+        --after=*)
+            since=$(echo "$1" | sed 's/--after=\(.*\)/\1/')
+            ;;
+        *)
+            usage
+            ;;
+    esac
+fi
 
 ( git local-branches; git remote-branches ) | while read branch; do
-    maybebranch=$(git log -1 --since=3.weeks.ago -s $branch)
+    maybebranch=$(
+        # set TRACE=1 in environment to show 'git log' commands as they're run
+        [ "${TRACE:-}" = 1 ] && set -x
+        git log -1 --since="$since" -s "$branch"
+    )
     [ -n "$maybebranch" ] && echo "$branch"
 done

--- a/git-active-branches
+++ b/git-active-branches
@@ -1,40 +1,35 @@
 #!/bin/sh
 set -eu
 
-since='3.weeks.ago'
+DEFAULT_SINCE='3.weeks.ago'
+since=$DEFAULT_SINCE
 
 usage() {
-    echo "usage: git active-branches [--since|--after <date>]" >&2
+    echo "usage: git active-branches [-s|-a <date>]" >&2
     echo >&2
-    echo "Unless specified, <date> defaults to \"$since\". For examples see:" >&2
+    echo "Options:" >&2
+    echo "-s      show branches active since <date> (as in 'git log --since')" >&2
+    echo "-a      (an alias for '-s')" >&2
+    echo "<date>  any date format recognized by 'git log'" >&2
+    echo >&2
+    echo "Unless specified, <date> defaults to \"$DEFAULT_SINCE\". For examples see:" >&2
     echo "https://git-scm.com/book/en/v2/Git-Basics-Viewing-the-Commit-History" >&2
-    exit 2
 }
 
-if [ $# -gt 0 ]; then
-    case $1 in
-        # 'git log' accepts either '--since' or '--after' as synonyms
-        --since|--after)
-            [ $# -eq 2 ] || usage
-            since=$2
-            ;;
-        --since=*)
-            since=$(echo "$1" | sed 's/--since=\(.*\)/\1/')
-            ;;
-        --after=*)
-            since=$(echo "$1" | sed 's/--after=\(.*\)/\1/')
-            ;;
-        *)
-            usage
-            ;;
+while [[ $# -gt 0 ]]; do
+    if ! getopts a:s:h flag; then usage; exit 2; fi
+    case "$flag" in
+        a|s) since=$OPTARG; shift ;;
+        \?)  usage; exit 2 ;;  # argument missing its option
+        h)   usage; exit 2 ;;
     esac
-fi
+    shift
+done
 
 ( git local-branches; git remote-branches ) | while read branch; do
+    # '--no-patch' = suppress diff output (long form of '-s')
     maybebranch=$(
-        # set TRACE=1 in environment to show 'git log' commands as they're run
-        [ "${TRACE:-}" = 1 ] && set -x
-        git log -1 --since="$since" -s "$branch"
+        git log -1 --since="$since" --no-patch "$branch"
     )
     [ -n "$maybebranch" ] && echo "$branch"
 done


### PR DESCRIPTION
* defaults to "3.weeks.ago" as before
    * specify a different date with `-s DATE` using any date format supported by [`git log`](https://git-scm.com/book/en/v2/Git-Basics-Viewing-the-Commit-History#_limiting_log_output)
* also accepts `-a` as an alias for `-s` (like `git log --after`)