### PR TITLE
Fall back to 'tac' when 'rev' is not available

### DIFF
--- a/git-modified
+++ b/git-modified
@@ -113,7 +113,9 @@ if [ -z "$commit" ]; then
     fi
 else
     TAB="	" # literal tab char
-    git log -1 --name-status --pretty=format:"" "$commit" | cut -f2- | rev | cut -d"$TAB" -f1 | rev | make_relative | while read f; do
+    rev='rev'
+    type rev >/dev/null 2>&1 || rev='tac'
+    git log -1 --name-status --pretty=format:"" "$commit" | cut -f2- | $rev | cut -d"$TAB" -f1 | $rev | make_relative | while read f; do
         if [ -f "$f" ]; then
             echo "$f"
         fi


### PR DESCRIPTION
- should allow toolbelt to run in Git Bash on Windows
- closes #29 (hopefully)