### PR TITLE
Add git-merge-directly-to

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Everyday helpful commands:
 * [git-local-branches](#git-local-branches--git-remote-branches--git-active-branches)
 * [git-local-commits](#git-local-commits)
 * [git-merged / git-unmerged / git-merge-status](#git-merged--git-unmerged--git-merge-status)
+* [git-merge-directly-to](#git-merge-directly-to)
 * [git-branches-containing](#git-branches-containing)
 * [git-recent-branches](#git-recent-branches)
 * [git-remote-branches](#git-local-branches--git-remote-branches--git-active-branches)
@@ -443,6 +444,22 @@ merged into the target branch (defaults to master).
 
 git-merge-status is a useful command that presents both lists in a single
 overview (not for machine processing).
+
+
+### git-merge-directly-to
+
+Works just like `merge` command, but instead of merging the specified branch into the current, it merges the current branch into the specified.
+
+When on branch `src`, the result of this:
+
+    git merge-directly-to dst
+
+Is the same as the result of this:
+
+    git checkout dst
+    git merge src
+
+But you don't actually checkout `dst` before the merge. Instead, `merge-directly-to` merges `dst` into `src` and then swaps parents of the merge commit. This is more efficient, and it won't touch the timestamps of the files you modified in `src`. This might be crucial for incremental builds.
 
 
 ### git-branches-containing

--- a/git-merge-directly-to
+++ b/git-merge-directly-to
@@ -18,13 +18,22 @@ src_sha=$(git rev-parse HEAD)  # e.g. f9cdd6d31d269995c2855546049b3ea1467212f0
 dst_in=$1  # e.g. refs/heads/team/tpe/visibility or team/tpe/visibility
 dst=${dst_in/#$prefix/}  # e.g. team/tpe/visibility
 dst_full=${prefix}$dst  # e.g. refs/heads/team/tpe/visibility
+dst_sha=$(git rev-parse $dst_full)  # e.g. ab0bd12e9f95fe81bf997d68389726e931762d84
 
-# Merge into src
-git merge $dst_full
-
-# Swap parents
 msg="Merge branch '$src' into $dst"
-head_sha=$(git commit-tree -p HEAD^2 -p HEAD^1 -m "$msg" "HEAD^{tree}")
+
+# Check if dst is an ancestor of src
+if [ "$(git merge-base HEAD $dst)" != "$dst_sha" ]
+then
+  # dst is not an ancestor or src, doing regular merge into src
+  git merge $dst_full
+  # Swap parents
+  head_sha=$(git commit-tree -p HEAD^2 -p HEAD^1 -m "$msg" "HEAD^{tree}")
+else
+  # dst is an ancestor or src, a regular merge would say "Already up to date" and do nothing
+  # Constructing a merge commit manually
+  head_sha=$(git commit-tree -p $dst_sha -p HEAD -m "$msg" "HEAD^{tree}")
+fi
 
 # Set dst to the new commit with swapped parents
 git update-ref $dst_full $head_sha

--- a/git-merge-directly-to
+++ b/git-merge-directly-to
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -eu
+
+usage () {
+    echo "usage: git merge-directly-to [<branch>]" >&2
+    echo >&2
+    echo "Merges current branch into the specified." >&2
+}
+
+prefix=refs/heads/
+
+# Current branch, that we want to merge from
+src=$(git symbolic-ref --short HEAD)  # e.g. dev/TRT-1234
+src_full=${prefix}$src  # e.g. refs/heads/dev/TRT-1234
+src_sha=$(git rev-parse HEAD)  # e.g. f9cdd6d31d269995c2855546049b3ea1467212f0
+
+# Destination branch, that we want to merge into
+dst_in=$1  # e.g. refs/heads/team/tpe/visibility or team/tpe/visibility
+dst=${dst_in/#$prefix/}  # e.g. team/tpe/visibility
+dst_full=${prefix}$dst  # e.g. refs/heads/team/tpe/visibility
+
+# Merge into src
+git merge $dst_full
+
+# Swap parents
+msg="Merge branch '$src' into $dst"
+head_sha=$(git commit-tree -p HEAD^2 -p HEAD^1 -m "$msg" "HEAD^{tree}")
+
+# Set dst to the new commit with swapped parents
+git update-ref $dst_full $head_sha
+
+# Switch to dst
+git switch $dst
+
+# Return src to where it was at the beginning
+git update-ref $src_full $src_sha


### PR DESCRIPTION
It works just like `merge` command, but instead of merging the specified branch into the current, it merges the current branch into the specified.

When on branch `src`, the result of this:

    git merge-directly-to dst

Is the same as the result of this:

    git checkout dst
    git merge src

But you don't actually checkout `dst` before the merge. Instead, `merge-directly-to` merges `dst` into `src` and then swaps parents of the merge commit. This is more efficient, and it won't touch the timestamps of the files you modified in `src`. This might be crucial for incremental builds.

The whole reason to create this command was to optimize incremental build times in huge C++ projects. It might save _hours_ comparing to the naive `merge`.