### PR TITLE
Add pandoc-based man pages generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ codes and have no output.
 * [git-is-headless](#git-is-headless)
 * [git-has-local-changes / git-is-clean / git-is-dirty](#git-has-local-changes--git-is-clean--git-is-dirty)
 * [git-has-local-commits](#git-has-local-commits)
-* [git-contains / git is-ancestor](#git-contains--git-is-ancestor)
+* [git-contains / git-is-ancestor](#git-contains--git-is-ancestor)
 * [git-local-branch-exists](#git-local-branch-exists)
 * [git-remote-branch-exists](#git-remote-branch-exists)
 * [git-tag-exists](#git-tag-exists)
@@ -76,7 +76,7 @@ Advanced usage:
 
 
 
-### git current-branch
+### git-current-branch
 
 Returns the name of the current branch, if any.  Why doesn't this come with git?
 
@@ -88,7 +88,7 @@ master
 Alias to `git rev-parse --abbrev-ref HEAD`.
 
 
-### git main-branch
+### git-main-branch
 
 Returns the name of the default main branch for this repository.  Historically
 `master`, but could also be `main` if you've changed the default branch name.
@@ -102,7 +102,7 @@ master
 ```
 
 
-### git sha
+### git-sha
 
 Returns the SHA value for the specified object, or the current branch head, if
 nothing is provided.
@@ -123,7 +123,7 @@ f688d75
 Shows the commit SHA for the latest commit.
 
 
-### git modified
+### git-modified
 
 Returns a list of locally modified files.  In contrast to git status, it does
 not include any detailed file status, and never includes non-existing files.
@@ -141,7 +141,7 @@ $ vim (git modified -i)
 ```
 
 
-### git modified-since
+### git-modified-since
 
 Like git-modified, but for printing a list of files that have been modified
 since master (or whatever commit specified).  In contrast to git status, it
@@ -155,7 +155,7 @@ $ vim (git modified-since)
 ```
 
 
-### git separator
+### git-separator
 
 Adds a commit with a message of only ---'s, so that it visually separates
 commits in the history.  This is incredibly useful when doing more complex
@@ -163,7 +163,7 @@ rebase operations.  (They should be used as a temporary measure, and ideally
 taken out of the history again when done rebasing.)
 
 
-### git spinoff
+### git-spinoff
 
 Inspired by Magit's `spinoff` command.  Creates and checks out
 a new branch starting at and tracking the current branch.  That
@@ -176,7 +176,7 @@ This is useful to create a feature branch after work has already
 began on the old branch (likely but not necessarily "master").
 
 
-### git push-current
+### git-push-current
 
 Pushed the current branch out to `origin`, and makes sure to setup tracking of
 the remote branch.  Shorthand for `git push -u origin <current-branch>`.
@@ -190,12 +190,12 @@ $ git push-current -f
 to force-push.
 
 
-### git is-headless
+### git-is-headless
 
 Tests if `HEAD` is pointing to a branch head, or is detached.
 
 
-### git local-branches / git remote-branches / git active-branches
+### git-local-branches / git-remote-branches / git-active-branches
 
 Returns a list of local or remote branches, but contrary to Git's default
 commands for this, returns them machine-processable.  In the case of remote
@@ -205,12 +205,12 @@ A branch is deemed "active" if its head points to a commit authored in the last
 3 weeks.
 
 
-### git local-branch-exists / git remote-branch-exists / git tag-exists
+### git-local-branch-exists / git-remote-branch-exists / git-tag-exists
 
 Tests if the given local branch, remote branch, or tag exists.
 
 
-### git recent-branches
+### git-recent-branches
 
 Returns a list of local branches, ordered by recency:
 
@@ -221,20 +221,20 @@ Returns a list of local branches, ordered by recency:
     qux
 
 
-### git remote-tracking-branch
+### git-remote-tracking-branch
 
 Print the name of the remote tracking branch of the current or
 given local branch name, if one exists.  Errors otherwise.
 
 
-### git local-commits / git has-local-commits
+### git-local-commits / git-has-local-commits
 
 Returns a list of commits that are still in your local repo, but haven't been
 pushed to `origin`.  `git has-local-commits` is the scriptable equivalent that
 only returns an exit code if such commits exist.
 
 
-### git contains / git is-ancestor
+### git-contains / git-is-ancestor
 
 Tests if X is merged into Y:
 
@@ -247,7 +247,7 @@ Even though they might look like opposites, `X contains Y` does not mean `not
 branches may have no common history and thus be unrelated completely.
 
 
-### git stage-all
+### git-stage-all
 
 Mimics the index / staging area to match the working tree exactly.  Adds files,
 removes files, etc.
@@ -255,20 +255,20 @@ removes files, etc.
 Alias to `git add --all`.
 
 
-### git unstage-all
+### git-unstage-all
 
 Unstages everything.  Leaves the working tree intact.
 
 Alias to `git reset HEAD`.
 
 
-### git undo-merge
+### git-undo-merge
 
 Ever created a merge accidentally, or decided that you didn't want to merge
 after all?  You can undo the last merge using `git undo-merge`.
 
 
-### git undo-commit
+### git-undo-commit
 
 Ever committed too soon, or by accident?  Or on the wrong branch?  You can now
 undo your last commit and you won't lose any data.  All the changes in the
@@ -276,14 +276,14 @@ commit will be staged (like right before the commit) and the commit itself is
 gone.
 
 
-### git cleanup
+### git-cleanup
 
 Deletes all branches that have already been merged into master or develop.
 Keeps other branches lying around.  Removes branches both locally and in the
 origin remote.  Will be most conservative with deletions.
 
 
-### git cleanup-squashed
+### git-cleanup-squashed
 
 Deletes all branches that have already been merged into master by means of
 squash-merging them.  Squashing them generally is a destructive operation.
@@ -292,7 +292,7 @@ into master.  If even the slightest difference is detected, the branch won't be
 deleted.
 
 
-### git fixup
+### git-fixup
 
 Amend all local staged changes into the last commit. Ideal for fixing typo's,
 when you don't want to re-edit the commit message.
@@ -303,21 +303,21 @@ when you don't want to re-edit the commit message.
     $ git fixup  # merge this little change back into the last commit
 
 
-### git fixup-with
+### git-fixup-with
 
 Interactively lets you pick a commit to fixup with.  (Uses `fzf` for the
 interactive picking.  Use `brew install fzf` to install this tool separately.)
 Use `-r` to trigger an interactive rebase right afterwards.
 
 
-### git workon
+### git-workon
 
 Convenience command for quickly switching to a branch `<name>`. If such local
 branch does not exist, but there is a remote branch named `origin/<name>`, then
 a local branch is created and the remote is tracked.
 
 
-### git delouse
+### git-delouse
 
 Say you want to rebuild your last commit, but want to keep the commit message.
 git delouse empties the last commit on the current branch and places all
@@ -327,7 +327,7 @@ Since the commit remains in history, you can now rebuild the commit by "git
 amend"'ing or "git fixup"'ing, instead of making new commits.
 
 
-### git shatter-by-file
+### git-shatter-by-file
 
 Splits the last commit into N+1 commits, where N is the number of files in the
 last commit.  The first commit is an empty commit with the original commit
@@ -340,7 +340,7 @@ original commit message is kept in there (in the empty first commit), so make
 sure to use it.
 
 
-### git commit-to
+### git-commit-to
 
 Ever been on a branch and really wanted to quickly commit a change to
 a different branch?  Given that this is possible without merge conflicts, git
@@ -358,7 +358,7 @@ commit-to will allow you to do so, without checking out the branch necessarily.
     $ git commit -m "Add bar to mybranch."
 
 
-### git cherry-pick-to
+### git-cherry-pick-to
 
 Every been on a branch, just made a commit, but really want that commit
 available on other branches as well? You can now cherry-pick this commit to any
@@ -376,13 +376,13 @@ conflict.)
     * mybranch
 
 
-### git is-repo
+### git-is-repo
 
 Helper function that determines whether the current directory has a Git repo
 associated to it.  Scriptable equivalent of `git repo`.
 
 
-### git root / git repo
+### git-root / git-repo
 
 `git root` prints the root location of the working tree.
 
@@ -405,7 +405,7 @@ in a repo.
     fatal: Not a git repository (or any of the parent directories): .git
 
 
-### git initial-commit
+### git-initial-commit
 
 `git initial-commit` prints the initial commit for the repo.
 
@@ -413,13 +413,13 @@ in a repo.
     48c94a6a29e9e52ab63ce0fab578101ddc56a04f
 
 
-### git has-local-changes / git is-clean / git is-dirty
+### git-has-local-changes / git-is-clean / git-is-dirty
 
 Helper function that determines whether there are local changes in the working
 tree, by returning a 0 (local changes) or 1 (no local changes) exit code.
 
 
-### git drop-local-changes
+### git-drop-local-changes
 
 Don't care about your local working copy's state and really want to revert back
 to whatever is recorded in the history? git drop-local-changes lets you do
@@ -432,7 +432,7 @@ committed remains safe.
 ??? issue a git pull, too? Typical beginners will want this.
 
 
-### git stash-everything
+### git-stash-everything
 
 The stash behaviour you (probably) always wanted.  This actually stashes
 everything what's in your index, in your working tree, and even stashes away
@@ -442,7 +442,7 @@ Using "git stash pop" will recover all changes, including index state, locally
 modified files, and untracked files.
 
 
-### git update-all
+### git-update-all
 
 Updates all local branch heads to the remote's equivalent.  This is the same as
 checking out all local branches one-by-one and pulling the latest upstream
@@ -476,8 +476,9 @@ Shows contribution stats for the given committer, like "most productive day",
 "most productive hour", "average commit size", etc.
 
 
-### TODO: git force-checkout
+### git-force-checkout
 
+**TODO:**
 Don't care about your local working copy's state and really want to switch to
 another branch? git force-checkout lets you do this.
 
@@ -498,7 +499,7 @@ a branch anyway. **You do agree to lose data when using this command.**
     Switched to branch 'master'
 
 
-### git conflicts
+### git-conflicts
 
 Generates a summary for all local branches that will merge uncleanly—i.e. will
 lead to merge conflicts later on.

--- a/readme2mans
+++ b/readme2mans
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+VER=${1:-unknown}
+DIR=${2:-mans}
+TEXT=""
+
+write_man() {
+	for tool in "$@"; do
+		echo "+${tool}"
+		echo "% ${tool^^}(1) git-toolbelt ${VER}
+% Vincent Driessen
+% `date --iso-8601`
+
+# NAME
+${tool}
+
+# DESCRIPTION
+${TEXT}
+
+# GIT TOOLBELT
+Part of the **git-toolbelt**(1) suite." | pandoc -s -t man -f markdown -o "${DIR}/${tool}.1"
+	done
+}
+
+mkdir -p "${DIR}" && rm -rf "${DIR}/*.1"
+
+while IFS='' read -r line || [ -n "${line}" ]; do
+	case "${line}" in
+	"# git"*)
+		TEXT=""
+		cmds=( git-toolbelt )
+		;;
+	"### git"*)
+		write_man "${cmds[@]}"
+		TEXT=""
+		IFS=' / ' cmds=(${line#"### "})
+		;;
+	*)
+		TEXT+="${line}"$'\n'
+		;;
+	esac
+done < README.md


### PR DESCRIPTION
Man pages are generated from the contents of `README.md` file.

It will be useful for packagers and would allow to have a handy help in form of `git sha --help`.