### PR TITLE
Ensure `grealpath` or `realpath` is the GNU version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
     $ brew tap nvie/tap
     $ brew install nvie/tap/git-toolbelt
 
+If not using Homebrew, you will need to have [GNU coreutils][coreutils]
+installed, for the `realpath` utility. Git for Windows users see #29.
+
 # git-tools
 
 Helper tools to make everyday life with Git much easier.  Commands marked with
@@ -536,3 +539,5 @@ Basic usage:
 As you can see, `git-is-clean` is aware of any lurking "skipped" files, and
 won't report a clean working tree, as these assumed unchanged files often block
 the ability to check out different branches.
+
+[coreutils]: https://www.gnu.org/software/coreutils/

--- a/git-autofixup
+++ b/git-autofixup
@@ -2,9 +2,14 @@
 set -e
 
 make_relative () {
+    realpath='realpath'
+    if ! type realpath >/dev/null 2>&1; then
+        # Mac/BSD ports system installs GNU coreutils with 'g' prefixes
+        realpath='grealpath'
+    fi
     root="$(git root)"
     while read f; do
-        echo "$(realpath --relative-to=. "$root/$f")"
+        echo "$($realpath --relative-to=. "$root/$f")"
     done
 }
 

--- a/git-modified
+++ b/git-modified
@@ -74,9 +74,14 @@ fix_rename_notation () {
 }
 
 make_relative () {
+    realpath='realpath'
+    if ! type realpath >/dev/null 2>&1; then
+        # Mac/BSD ports system installs GNU coreutils with 'g' prefixes
+        realpath='grealpath'
+    fi
     root="$(git root)"
     while read f; do
-        echo "$(realpath --relative-to=. "$root/$f")"
+        echo "$($realpath --relative-to=. "$root/$f")"
     done
 }
 

--- a/git-modified-since
+++ b/git-modified-since
@@ -30,9 +30,14 @@ if [ $# -ge 1 ]; then
 fi
 
 make_relative () {
+    realpath='realpath'
+    if ! type realpath >/dev/null 2>&1; then
+        # Mac/BSD ports system installs GNU coreutils with 'g' prefixes
+        realpath='grealpath'
+    fi
     root="$(git root)"
     while read f; do
-        echo "$(realpath --relative-to=. "$root/$f")"
+        echo "$($realpath --relative-to=. "$root/$f")"
     done
 }
 

--- a/git-relative-path
+++ b/git-relative-path
@@ -16,15 +16,7 @@ if ! "$realpath_bin" --version 2>/dev/null | grep -q GNU; then
     exit 2
 fi
 
-# read filenames as arguments if stdin is a terminal (not a pipe)
-if [ -t 0 ]; then
-    while [ $# -gt 0 ]; do
-        "$realpath_bin" --relative-to=. "$root/$1"
-        shift
-    done
-else
-    # otherwise read linewise from stdin (preserving any \'s and whitespace)
-    while IFS= read -r f; do
-        "$realpath_bin" --relative-to=. "$root/$f"
-    done
-fi
+while [ $# -gt 0 ]; do
+    "$realpath_bin" --relative-to=. "$root/$1"
+    shift
+done

--- a/git-relative-path
+++ b/git-relative-path
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+root="$(git root)"
+realpath='realpath'
+
+# use 'grealpath' from GNU coreutils if it exists on macOS/BSD
+if type grealpath >/dev/null 2>&1; then
+    realpath='grealpath'
+fi
+
+# if 'realpath' isn't available, or isn't the GNU version...
+if ! $realpath --version 2>/dev/null | grep -q GNU; then
+    echo "GNU coreutils 'realpath' is required" >&2
+    exit 2
+fi
+
+# read filenames as arguments if stdin is a terminal (not a pipe)
+if [ -t 0 ]; then
+    while [ $# -gt 0 ]; do
+        $realpath --relative-to=. "$root/$1"
+        shift
+    done
+else
+    # otherwise read linewise from stdin (preserving any \'s and whitespace)
+    while IFS= read -r f; do
+        $realpath --relative-to=. "$root/$f"
+    done
+fi


### PR DESCRIPTION
Based on #38, and adjusted to work on the recent breaking change introduced by `coreutils` on Brew. Thanks @ernstki for the initial work here!