### PR TITLE
Add 'mainline' as a main branch.

### DIFF
--- a/git-main-branch
+++ b/git-main-branch
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-for probe in main master; do
+for probe in main mainline master; do
     if git local-branch-exists "$probe"; then
         echo "$probe"
         exit 0


### PR DESCRIPTION
The `git-main-branch` script is called from within other scripts, but not all users use `main` or `master` as their main branch.

Companies migrating from perforce use `mainline` as their main branch name. For example, Amazon/AWS have been using `mainline` since migrating to git in the early 2000s. There are thousands of repositories at Amazon, all with `mainline` as their branch.

### Further considerations
It may be nice to consider `trunk` for migrations from subversion and `default` for migrations from mercurial? I cannot speak to how migrations to git from these systems work.

### Alternatives
* Use `$(git config --get git-toolbelt.main-branch)`
  * Use `$(git config --get-all git-toolbelt.main-branch)` to allow multiple values to be set
  * Both these options work with bash's `set -eu -o pipefail` if no option is set
* Accept a global `GTB_MAIN_BRANCH` or `GTB_MAIN_BRANCHES` environment variable
* Accept a `~/.config/git-toolbelt/main-branch` input file, but I don't know how well that plays with Windows systems.