### PR TITLE
Support on Windows OS (#29)

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -1,0 +1,18 @@
+name: Windows CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests (bash)
+        env:
+          REPO_ROOT: ${{ github.workspace }}
+        run: |
+          chmod +x tests/test-git-modified.sh || true
+          bash tests/test-git-modified.sh
+        shell: bash

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@
     $ brew tap nvie/tap
     $ brew install nvie/tap/git-toolbelt
 
-If not using Homebrew, you will need to have [GNU coreutils][coreutils]
-installed, for the `realpath` utility. Git for Windows users see [#29](https://github.com/nvie/git-toolbelt/issues/29).
+If not using Homebrew, you will need to have [GNU coreutils][coreutils] installed for the `realpath` utility.
+
+Windows support: These scripts are POSIX shell scripts and are known to work under Git for Windows (Git Bash) or via WSL. A recent change removed reliance on the external `rev` utility so `git-modified` works in Git Bash without extra tools. CI now includes a windows-latest job to catch regressions. If you need to run them in native PowerShell, prefer using WSL or Git Bash for full compatibility.
 
 # git-toolbelt
 

--- a/git-modified
+++ b/git-modified
@@ -170,13 +170,13 @@ if [ -z "$commit" ]; then
 else
     TAB="	" # literal tab char
     if [ $# -gt 0 ]; then
-        git log -1 --name-status --pretty=format:"" "$commit" -- "$@" | cut -f2- | rev | cut -d"$TAB" -f1 | rev | make_relative | while read f; do
+        git log -1 --name-status --pretty=format:"" "$commit" -- "$@" | cut -f2- | awk -F"$TAB" '{print $NF}' | make_relative | while read f; do
             if [ -f "$f" ]; then
                 echo "$f"
             fi
         done | fail_if_empty
     else
-        git log -1 --name-status --pretty=format:"" "$commit" | cut -f2- | rev | cut -d"$TAB" -f1 | rev | make_relative | while read f; do
+        git log -1 --name-status --pretty=format:"" "$commit" | cut -f2- | awk -F"$TAB" '{print $NF}' | make_relative | while read f; do
             if [ -f "$f" ]; then
                 echo "$f"
             fi

--- a/tests/test-git-modified.sh
+++ b/tests/test-git-modified.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+if [ -z "$REPO_ROOT" ]; then
+  echo "REPO_ROOT must be set to repository root to find git-modified" >&2
+  exit 2
+fi
+
+TMPDIR=$(mktemp -d)
+cd "$TMPDIR"
+
+# initialize a new repo to test git-modified behavior
+git init -q
+printf 'hello' > a.txt
+git add a.txt
+git commit -q -m "add a"
+
+COMMIT=$(git rev-parse --verify --quiet HEAD)
+
+# Run git-modified from the repo under test
+OUT=$("$REPO_ROOT/git-modified" "$COMMIT")
+
+if [ "$OUT" = "a.txt" ]; then
+  echo "ok: git-modified produced expected output"
+  exit 0
+else
+  echo "fail: git-modified output was: '$OUT'" >&2
+  exit 1
+fi


### PR DESCRIPTION
Fixes and CI to improve Windows compatibility.

- Replace rev-based pipeline in `git-modified` with a more portable awk-based extraction so scripts work in Git Bash (Git for Windows).
- Add a small integration test reproducing `git-modified` behavior.
- Add a GitHub Actions job running tests on `windows-latest`.
- Update README with Windows support notes.

Closes #29

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>